### PR TITLE
searchTextに初期値を設定

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -9,7 +9,7 @@ export function Header({ app }: { app: AppMeta }): JSX.Element {
   const { q } = router.query;
   const searchRef = useRef<HTMLInputElement>();
 
-  const [searchText, setSearchText] = useState(q);
+  const [searchText, setSearchText] = useState(q || "");
 
   const focus = useCallback(() => {
     if (searchRef.current) {


### PR DESCRIPTION
以下のwarningが出ているので、初期値を設定して対応する。

<img width="671" alt="Screen Shot 2022-10-11 at 8 51 39" src="https://user-images.githubusercontent.com/14175298/194969745-2831fd4a-858f-4f21-aacd-08bfa12bfea2.png">
